### PR TITLE
Resolution options

### DIFF
--- a/code/main.cpp
+++ b/code/main.cpp
@@ -338,17 +338,21 @@ int main()
 	int resIndex = 0;
 	bool isFullscreen = true;
 
+	// Create window to select resolution
 	sf::RenderWindow choose_res(sf::VideoMode(resolutions[0][0], resolutions[0][1]), "Select Resolution", sf::Style::Default);
 	sf::Font fontRes;
 	fontRes.loadFromFile("resources\\menu.ttf");
+	// Define texts
 	sf::Text choose_res_text, res_text, fullscreen_text;
 	choose_res_text.setFont(fontRes);
+	// Make select resolution text
 	choose_res_text.setString("Select Resolution");
 	choose_res_text.setCharacterSize(100);
 	choose_res_text.setColor(sf::Color::White);
 	choose_res_text.setStyle(sf::Text::Regular);
 	choose_res_text.setOrigin((choose_res_text.getLocalBounds().width) / 2, 0);
 	choose_res_text.setPosition((choose_res.getSize().x / 2), 20);
+	// Make text displaying currently selected resolution
 	res_text.setFont(fontRes);
 	res_text.setString("1920x1080");
 	res_text.setCharacterSize(150);
@@ -356,6 +360,7 @@ int main()
 	res_text.setStyle(sf::Text::Regular);
 	res_text.setOrigin((res_text.getLocalBounds().width) / 2, (res_text.getLocalBounds().height) / 2);
 	res_text.setPosition((choose_res.getSize().x / 2), 200);
+	// Create up and down arrows
 	sf::CircleShape up_arrow(80, 3), down_arrow(80, 3);
 	up_arrow.setOrigin(up_arrow.getLocalBounds().width / 2, up_arrow.getLocalBounds().height);
 	down_arrow.setOrigin((up_arrow.getLocalBounds().width / 2), 0);
@@ -364,7 +369,7 @@ int main()
 	int res_textPos = res_text.getPosition().x;
 	up_arrow.setPosition(res_textPos, res_text.getPosition().y+20);
 	down_arrow.setPosition(res_textPos, res_text.getPosition().y + 190);
-
+	// Create text indicating fullscreen status
 	fullscreen_text.setFont(fontRes);
 	fullscreen_text.setString("F for Fullscreen");
 	fullscreen_text.setCharacterSize(100);
@@ -380,12 +385,30 @@ int main()
 		{
 			if (event.type == sf::Event::Closed)
 				choose_res.close();
+			// Up arrow means increase resolution
 			if (event.type == sf::Event::KeyPressed && (event.key.code == sf::Keyboard::Up))
-				if (resIndex < sizeof(resolutions) / sizeof(sf::VideoMode)) resIndex++;
+			{
+				if (resIndex <= sizeof(resolutions) / sizeof(sf::VideoMode))
+				{
+					resIndex++;
+					up_arrow.setFillColor(sf::Color::White);
+				}
+				else up_arrow.setFillColor(sf::Color::Transparent);
+			}
+			// Down arrow means decrease resolution
 			if (event.type == sf::Event::KeyPressed && (event.key.code == sf::Keyboard::Down))
-				if (resIndex > 0) resIndex--;
+			{
+				if (resIndex > 0)
+				{
+					resIndex--;
+					down_arrow.setFillColor(sf::Color::White);
+				}
+				else down_arrow.setFillColor(sf::Color::Transparent);
+			}
+			// Enter means play game
 			if (event.type == sf::Event::KeyPressed && (event.key.code == sf::Keyboard::Enter))
 				choose_res.close();
+			// F toggles fullscreen mode
 			if (event.type == sf::Event::KeyPressed && (event.key.code == sf::Keyboard::F))
 			{
 				isFullscreen = !isFullscreen;

--- a/code/main.cpp
+++ b/code/main.cpp
@@ -322,8 +322,93 @@ int main()
 	sf::Image icon;
 	icon.loadFromFile("resources\\icon.png");
 
+	// Resolutions
+	int resolutions[][2] = {
+		{1025, 576},
+		{1152, 648},
+		{1280, 720},
+		{1366, 768},
+		{1600, 900},
+		{1920, 1080},
+		{2560, 1440},
+		{3840, 2160},
+		{7680, 4320},
+	};
+
+	int resIndex = 0;
+	bool isFullscreen = true;
+
+	sf::RenderWindow choose_res(sf::VideoMode(resolutions[0][0], resolutions[0][1]), "Select Resolution", sf::Style::Default);
+	sf::Font fontRes;
+	fontRes.loadFromFile("resources\\menu.ttf");
+	sf::Text choose_res_text, res_text, fullscreen_text;
+	choose_res_text.setFont(fontRes);
+	choose_res_text.setString("Select Resolution");
+	choose_res_text.setCharacterSize(100);
+	choose_res_text.setColor(sf::Color::White);
+	choose_res_text.setStyle(sf::Text::Regular);
+	choose_res_text.setOrigin((choose_res_text.getLocalBounds().width) / 2, 0);
+	choose_res_text.setPosition((choose_res.getSize().x / 2), 20);
+	res_text.setFont(fontRes);
+	res_text.setString("1920x1080");
+	res_text.setCharacterSize(150);
+	res_text.setColor(sf::Color::White);
+	res_text.setStyle(sf::Text::Regular);
+	res_text.setOrigin((res_text.getLocalBounds().width) / 2, (res_text.getLocalBounds().height) / 2);
+	res_text.setPosition((choose_res.getSize().x / 2), 200);
+	sf::CircleShape up_arrow(80, 3), down_arrow(80, 3);
+	up_arrow.setOrigin(up_arrow.getLocalBounds().width / 2, up_arrow.getLocalBounds().height);
+	down_arrow.setOrigin((up_arrow.getLocalBounds().width / 2), 0);
+	up_arrow.scale(1, 0.5);
+	down_arrow.scale(1, -0.5);
+	int res_textPos = res_text.getPosition().x;
+	up_arrow.setPosition(res_textPos, res_text.getPosition().y+20);
+	down_arrow.setPosition(res_textPos, res_text.getPosition().y + 190);
+
+	fullscreen_text.setFont(fontRes);
+	fullscreen_text.setString("F for Fullscreen");
+	fullscreen_text.setCharacterSize(100);
+	fullscreen_text.setColor(sf::Color::Green);
+	fullscreen_text.setStyle(sf::Text::Regular);
+	fullscreen_text.setOrigin((fullscreen_text.getLocalBounds().width) / 2, (fullscreen_text.getLocalBounds().height) / 2);
+	fullscreen_text.setPosition((choose_res.getSize().x / 2), 400);
+
+	while (choose_res.isOpen())
+	{
+		sf::Event event;
+		while (choose_res.pollEvent(event))
+		{
+			if (event.type == sf::Event::Closed)
+				choose_res.close();
+			if (event.type == sf::Event::KeyPressed && (event.key.code == sf::Keyboard::Up))
+				if (resIndex < sizeof(resolutions) / sizeof(sf::VideoMode)) resIndex++;
+			if (event.type == sf::Event::KeyPressed && (event.key.code == sf::Keyboard::Down))
+				if (resIndex > 0) resIndex--;
+			if (event.type == sf::Event::KeyPressed && (event.key.code == sf::Keyboard::Enter))
+				choose_res.close();
+			if (event.type == sf::Event::KeyPressed && (event.key.code == sf::Keyboard::F))
+			{
+				isFullscreen = !isFullscreen;
+				fullscreen_text.setColor(isFullscreen ? sf::Color::Green : sf::Color::Red);
+			}
+				
+		}
+
+		res_text.setString(std::to_string(resolutions[resIndex][0])+"x"+std::to_string(resolutions[resIndex][1]));
+		res_text.setOrigin((res_text.getLocalBounds().width) / 2, (res_text.getLocalBounds().height) / 2);
+		res_text.setPosition((choose_res.getSize().x / 2), 200);
+
+		choose_res.clear();
+		choose_res.draw(choose_res_text);
+		choose_res.draw(res_text);
+		choose_res.draw(up_arrow);
+		choose_res.draw(down_arrow);
+		choose_res.draw(fullscreen_text);
+		choose_res.display();
+	}
+
 	//initialises the window
-	sf::RenderWindow window(sf::VideoMode(1920, 1080), "Pong", sf::Style::Fullscreen);
+	sf::RenderWindow window(sf::VideoMode(resolutions[resIndex][0], resolutions[resIndex][1]), "Pong", isFullscreen ? sf::Style::Fullscreen : sf::Style::Default);
 	window.setVerticalSyncEnabled(true);
 	window.setIcon(icon.getSize().x, icon.getSize().y, icon.getPixelsPtr());
 

--- a/code/main.cpp
+++ b/code/main.cpp
@@ -388,7 +388,7 @@ int main()
 			// Up arrow means increase resolution
 			if (event.type == sf::Event::KeyPressed && (event.key.code == sf::Keyboard::Up))
 			{
-				if (resIndex <= sizeof(resolutions) / sizeof(sf::VideoMode))
+				if (resIndex+1 < sizeof(resolutions) / sizeof(sf::VideoMode))
 				{
 					resIndex++;
 					up_arrow.setFillColor(sf::Color::White);


### PR DESCRIPTION
A window now opens when the game is launched which allows the user to select their preferred resolution and whether they want fullscreen mode turned off or on.
Changing resolution is done using the up and down arrow keys, while toggling fullscreen mode is achieved by pressing the F key.
Should close #1 